### PR TITLE
Fixing "Config option not found" message for missing rtmp port

### DIFF
--- a/src/org/czentral/incubator/streamm/Bootstrap.java
+++ b/src/org/czentral/incubator/streamm/Bootstrap.java
@@ -119,7 +119,7 @@ public class Bootstrap {
 
             String rtmpPortProp = props.getProperty("rtmp.port");
             if (rtmpPortProp == null) {
-                throw new RuntimeException("Config option not found: http.port.");
+                throw new RuntimeException("Config option not found: rtmp.port.");
             }
             int rtmpPort = Integer.parseInt(rtmpPortProp);
             MiniRTMP server = new MiniRTMP(rtmpPort, library);


### PR DESCRIPTION
Small fix for missing rtmp port in config file.