### PR TITLE
Update MiniRTMP.java

### DIFF
--- a/src/main/java/org/czentral/minirtmp/MiniRTMP.java
+++ b/src/main/java/org/czentral/minirtmp/MiniRTMP.java
@@ -80,11 +80,11 @@ public class MiniRTMP implements Runnable {
             }
             
             ResourceLimit limit = new ResourceLimit();
-            limit.chunkStreamCount = 8;
-            limit.assemblyBufferCount = 2;
-            limit.assemblyBufferSize = 4096;
+            limit.chunkStreamCount = 32;
+            limit.assemblyBufferCount = 8;
+            limit.assemblyBufferSize = 16384;
             
-            Feeder feeder = new Feeder(new Buffer(65536), is);
+            Feeder feeder = new Feeder(new Buffer(262144), is);
             
             HandshakeProcessor handshake = new HandshakeProcessor(os);
             feeder.feedTo(handshake);

--- a/src/main/java/org/czentral/minirtmp/MiniRTMP.java
+++ b/src/main/java/org/czentral/minirtmp/MiniRTMP.java
@@ -80,9 +80,9 @@ public class MiniRTMP implements Runnable {
             }
             
             ResourceLimit limit = new ResourceLimit();
-            limit.chunkStreamCount = 32;
-            limit.assemblyBufferCount = 8;
-            limit.assemblyBufferSize = 16384;
+            limit.chunkStreamCount = 8;
+            limit.assemblyBufferCount = 2;
+            limit.assemblyBufferSize = 4096;
             
             Feeder feeder = new Feeder(new Buffer(262144), is);
             


### PR DESCRIPTION
While the MovieFragment interface can keep up with high quality streams, the MiniRTMP had too low of numbers to ingest them.

25 frames per second and 1500kbits stream with an keyframe every 2 seconds would need about 10kbytes. So the next good number would be 16384. Also the needs to be big enough to keep the new bigger Buffersize. At last i also increased chunkStreamCount and assemblyBufferCount because stream m kept on running into errors.