### PR TITLE
High Quality Streaming Fixes And Stability

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GitSharedSettings">
+    <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
+      <list />
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="GitSharedSettings">
-    <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
-      <list />
-    </option>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />

--- a/src/main/java/org/czentral/incubator/streamm/MovieFragment.java
+++ b/src/main/java/org/czentral/incubator/streamm/MovieFragment.java
@@ -27,7 +27,7 @@ public interface MovieFragment {
 
     public static int LIMIT_FRAME_MINIMUM = 100 * 1024;
     
-    public static int LIMIT_FRAME_MAXIMUM = 2048 * 1024 + 64 * 1024;
+    public static int LIMIT_FRAME_MAXIMUM = 10 * 2048 * 1024 + 64 * 1024;
     
     public Buffer[] getBuffers();
 

--- a/src/main/java/org/czentral/incubator/streamm/PublisherAppInstance.java
+++ b/src/main/java/org/czentral/incubator/streamm/PublisherAppInstance.java
@@ -253,9 +253,9 @@ class PublisherAppInstance implements ApplicationInstance {
         }
         
         // raise limit after successful authentication
-        context.getLimit().assemblyBufferSize = 2 * 1024 * 1024;
-        context.getLimit().assemblyBufferCount = 16;
-        context.getLimit().chunkStreamCount = 32;
+        context.getLimit().assemblyBufferSize = 50 * 1024 * 1024;
+        context.getLimit().assemblyBufferCount = 128;
+        context.getLimit().chunkStreamCount = 256;
         
         streamID = clientStreamID;
         

--- a/src/main/java/org/czentral/incubator/streamm/StreamInput.java
+++ b/src/main/java/org/czentral/incubator/streamm/StreamInput.java
@@ -18,6 +18,8 @@
 package org.czentral.incubator.streamm;
 
 import java.io.*;
+
+import org.czentral.minirtmp.RestartStreamerException;
 import org.czentral.util.stream.Buffer;
 import org.czentral.util.stream.Feeder;
 
@@ -42,11 +44,19 @@ public class StreamInput {
         Feeder feeder = new Feeder(buffer, input);
         
         HeaderDetectionState hds = new HeaderDetectionState(this, stream);
-        feeder.feedTo(hds);
+        try {
+            feeder.feedTo(hds);
+        } catch (RestartStreamerException e) {
+            e.printStackTrace();
+        }
 
         StreamingState ss = new StreamingState(this, stream, hds.getVideoTrackNumber());
-        feeder.feedTo(ss);
-        
+        try {
+            feeder.feedTo(ss);
+        } catch (RestartStreamerException e) {
+            e.printStackTrace();
+        }
+
         // notification about ending the input process
         stream.postEvent(new ServerEvent(this, stream, ServerEvent.INPUT_STOP));
     }

--- a/src/main/java/org/czentral/minihttp/HTTPRequestLoader.java
+++ b/src/main/java/org/czentral/minihttp/HTTPRequestLoader.java
@@ -19,6 +19,8 @@ package org.czentral.minihttp;
 import java.io.*;
 import java.net.*;
 import java.util.*;
+
+import org.czentral.minirtmp.RestartStreamerException;
 import org.czentral.util.stream.*;
 
 /**
@@ -236,7 +238,11 @@ class HTTPRequestLoader implements HTTPRequest {
         if (state >= STATE_REQUEST_LINE_LOADED)
             return;
 
-        feeder.feedTo(new RequestLineLoader());
+        try {
+            feeder.feedTo(new RequestLineLoader());
+        } catch (RestartStreamerException e) {
+            e.printStackTrace();
+        }
         state = STATE_REQUEST_LINE_LOADED;
     }
     
@@ -247,7 +253,11 @@ class HTTPRequestLoader implements HTTPRequest {
         loadRequestLine();
         
         RequestHeaderLoader loader = new RequestHeaderLoader();
-        feeder.feedTo(loader);
+        try {
+            feeder.feedTo(loader);
+        } catch (RestartStreamerException e) {
+            e.printStackTrace();
+        }
         requestHeaders = loader.getCompactMap();
         
         state = STATE_REQUEST_HEADERS_LOADED;

--- a/src/main/java/org/czentral/minihttp/MiniHTTP.java
+++ b/src/main/java/org/czentral/minihttp/MiniHTTP.java
@@ -80,8 +80,8 @@ public class MiniHTTP extends Thread {
             InputStream is;
             OutputStream os;
             try {
-                is = sock.getInputStream();
-                os = sock.getOutputStream();
+                is = new BufferedInputStream(sock.getInputStream());
+                os = new BufferedOutputStream(sock.getOutputStream());
             } catch (IOException e) {
                 throw new RuntimeException("Error opening streams");
             }

--- a/src/main/java/org/czentral/minirtmp/MiniRTMP.java
+++ b/src/main/java/org/czentral/minirtmp/MiniRTMP.java
@@ -74,7 +74,7 @@ public class MiniRTMP implements Runnable {
             OutputStream os;
             try {
                 is = new BufferedInputStream(sock.getInputStream());
-                os = sock.getOutputStream();
+                os = new BufferedOutputStream(sock.getOutputStream());
             } catch (IOException e) {
                 throw new RuntimeException("Error opening streams");
             }
@@ -85,7 +85,7 @@ public class MiniRTMP implements Runnable {
             limit.assemblyBufferSize = 4096;
             
             Feeder feeder = new Feeder(new Buffer(262144), is);
-            
+
             HandshakeProcessor handshake = new HandshakeProcessor(os);
             try {
                 feeder.feedTo(handshake);
@@ -94,11 +94,6 @@ public class MiniRTMP implements Runnable {
             }
 
             String clientId = sock.getRemoteSocketAddress().toString();
-            try {
-                sock.setReceiveBufferSize(1024*1024);
-            } catch (SocketException e) {
-                e.printStackTrace();
-            }
             ApplicationContext context = new ApplicationContext(os, limit, factory, clientId);
             try {
                 feeder.feedTo(new RTMPStreamProcessor(limit, context));

--- a/src/main/java/org/czentral/minirtmp/MiniRTMP.java
+++ b/src/main/java/org/czentral/minirtmp/MiniRTMP.java
@@ -98,8 +98,6 @@ public class MiniRTMP implements Runnable {
             try {
                 feeder.feedTo(new RTMPStreamProcessor(limit, context));
             } catch (RestartStreamerException e) {
-                e.printStackTrace();
-                System.out.println("restart");
                 System.out.println(e.getMessage());
                 feeder = new Feeder(new Buffer(262144), is);
                 try {

--- a/src/main/java/org/czentral/minirtmp/RTMPStreamProcessor.java
+++ b/src/main/java/org/czentral/minirtmp/RTMPStreamProcessor.java
@@ -69,7 +69,7 @@ class RTMPStreamProcessor implements Processor {
     }
 
     @Override
-    public int process(byte[] buffer, int offset, int length) {
+    public int process(byte[] buffer, int offset, int length) throws RestartStreamerException {
         int bytesProcessed = 0;
         do {
             int packetBytes = processPacket(buffer, offset + bytesProcessed, length - bytesProcessed);
@@ -82,7 +82,7 @@ class RTMPStreamProcessor implements Processor {
     }
 
 
-    public int processPacket(byte[] buffer, int offset, int length) {
+    public int processPacket(byte[] buffer, int offset, int length) throws RestartStreamerException {
         if (length < 1) {
             return 0;
         }
@@ -101,7 +101,7 @@ class RTMPStreamProcessor implements Processor {
                 //System.out.println(op.get());
             } catch (RtmpException e) {
                 e.printStackTrace();
-                return 0;
+                throw new RestartStreamerException(e.getMessage());
             }
         }
         //if (bb.remaining() < lastPacket.payloadLegth) {

--- a/src/main/java/org/czentral/minirtmp/RestartStreamerException.java
+++ b/src/main/java/org/czentral/minirtmp/RestartStreamerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Bence Varga
+ * Copyright 2019 Bence Varga
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -15,37 +15,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
+package org.czentral.minirtmp;
 
-package org.czentral.util.stream;
+public class RestartStreamerException extends Exception {
+    public RestartStreamerException() {
+        super();
+    }
 
-import org.czentral.minirtmp.RestartStreamerException;
-
-/**
- *
- * @author bence
- */
-public interface Processor {
-
-    /**
-     * Checks if this processor has finished its job.
-     *
-     * @return <code>true</code> if this processor extracted all the data.
-     */
-    boolean finished();
-
-    /**
-     * Process binary data from this buffer.
-     *
-     * @param buffer The buffer of data.
-     * @param offset The offset of the first byte which needs to be processed within the buffer.
-     * @param length The number of data bytes need to be processed.
-     * @return Number of bytes successfully processed.
-     */
-    int process(byte[] buffer, int offset, int length) throws RestartStreamerException;
-    
+    public RestartStreamerException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/org/czentral/util/stream/Feeder.java
+++ b/src/main/java/org/czentral/util/stream/Feeder.java
@@ -18,6 +18,8 @@
 package org.czentral.util.stream;
 
 
+import org.czentral.minirtmp.RestartStreamerException;
+
 import java.io.*;
 
 /**
@@ -44,7 +46,7 @@ public class Feeder {
     /**
      * Feeds the input to a <code>Processor</code> until it finishes its work.
      */
-    public void feedTo(Processor processor) {
+    public void feedTo(Processor processor) throws RestartStreamerException {
         byte[] data = buffer.getData();
         
         do {

--- a/src/main/java/org/czentral/util/stream/MeasuredOutputStream.java
+++ b/src/main/java/org/czentral/util/stream/MeasuredOutputStream.java
@@ -35,7 +35,7 @@ import org.czentral.incubator.streamm.Stream;
  */
 public class MeasuredOutputStream extends OutputStream {
     
-    private final int DEFAULT_PACKET_SIZE = 64 * 1024;
+    private final int DEFAULT_PACKET_SIZE = 1024 * 1024;
 
     protected OutputStream base;
     protected EventSource source;


### PR DESCRIPTION
Hi again,

after some trial and error I found out, that an read() from an inputstream would only return 1MB which sometimes would not be enough and crash the whole server. This can be fixed by wrapping the inputstream into an bufferedinputstream which now makes the whole server way more stable for my use cases.

Further I increased some of limits by A LOT. In some cases perhaps way too much. But with this configuration it seemed to get the best results for my case.

At last I added an RestartStreamException which is thrown when something happens, which in other cases would kill the server. This now just show the error message, but restart the thread which will then continue to serve the stream.

When creating this pull request I noticed that IntelliJ made a lot of whitespace changes. If this bothers you, I can redo the changes on a new pull request.